### PR TITLE
Check for null values during search to avoid throwing javascript erro…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -125,6 +125,10 @@ module.exports = {
     var search = function search(data) {
       var i;
       var value;
+      
+      if (!data) {
+        return null;
+      }
 
       if (data instanceof Array) {
         for (i = 0; i < data.length; i++) {


### PR DESCRIPTION
…rs when an object has a property with an explicit null value

This is a small fix for issue #6 that I logged.